### PR TITLE
chore: Add codecov yml settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             cpu: amd64
           #- os: windows
             #cpu: i386
-        branch: [version-1-2, version-1-4, version-1-6, devel]
+        branch: [version-1-2, version-1-4, version-1-6]
         include:
           - target:
               os: linux

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,4 @@
-name: Code Coverage
+name: Generate and upload code coverage
 
 on:
   #On push to common branches, this computes the "bases stats" for PRs

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        # advanced settings
+
+        # Prevents PR from being blocked with a reduction in coverage.
+        # Note, if we want to re-enable this, a `threshold` value can be used
+        # allow coverage to drop by x% while still posting a success status.
+        # `informational`: https://docs.codecov.com/docs/commit-status#informational
+        # `threshold`: https://docs.codecov.com/docs/commit-status#threshold
+        informational: true


### PR DESCRIPTION
Specify `informational: true` to prevent CI failure with a reduction in code coverage. We are not at a point yet to need this.