### PR TITLE
feat: Swap PeerRecord for SignedPeerRecord (PR comments)

### DIFF
--- a/libp2pdht.nimble
+++ b/libp2pdht.nimble
@@ -14,7 +14,7 @@ requires "nim >= 1.2.0",
          "chronicles >= 0.10.2 & < 0.11.0",
          "chronos >= 3.0.11 & < 3.1.0",
          "eth >= 1.0.0 & < 1.1.0", # to be removed in https://github.com/status-im/nim-libp2p-dht/issues/2
-         "libp2p#316f205381f9015402a53009c8f61bf17d2989b5",
+         "libp2p#22fe39819ae8b3118a59e3962ea42087f878c5b6",
          "metrics",
          "protobufserialization >= 0.2.0 & < 0.3.0",
          "secp256k1 >= 0.5.2 & < 0.6.0",

--- a/libp2pdht/dht/providers_encoding.nim
+++ b/libp2pdht/dht/providers_encoding.nim
@@ -43,11 +43,6 @@ func write*[T: SignedPeerRecord | PeerRecord | Envelope](
   let encoded = env.encode().tryGet()
   write(pb, field, encoded)
 
-# TODO: This should be included upstream in libp2p/signed_envelope. Once it's
-# added in libp2p, we can remove it from here.
-proc encode*[T](msg: SignedPayload[T]): Result[seq[byte], CryptoError] =
-  msg.envelope.encode()
-
 proc getRepeatedField*(pb: ProtoBuffer, field: int,
                        value: var seq[SignedPeerRecord]): ProtoResult[bool] {.
      inline.} =

--- a/tests/dht/test_helper.nim
+++ b/tests/dht/test_helper.nim
@@ -2,7 +2,8 @@ import
   stew/shims/net, bearssl, chronos,
   eth/keys,
   libp2pdht/discv5/[enr, node, routing_table],
-  libp2pdht/discv5/protocol as discv5_protocol
+  libp2pdht/discv5/protocol as discv5_protocol,
+  libp2p/multiaddress
 
 export net
 
@@ -53,3 +54,13 @@ proc generateNRandomNodes*(rng: ref BrHmacDrbgContext, n: int): seq[Node] =
     let node = generateNode(PrivateKey.random(rng[]))
     res.add(node)
   res
+
+func udpExample*(_: type MultiAddress): MultiAddress =
+  ## creates a new udp multiaddress on a random port
+  Multiaddress.init("/ip4/0.0.0.0/udp/0")
+
+func udpExamples*(_: type MultiAddress, count: int): seq[MultiAddress] =
+  var res: seq[MultiAddress] = @[]
+  for i in 1..count:
+    res.add Multiaddress.init("/ip4/0.0.0.0/udp/" & $i).get
+  return res

--- a/tests/dht/test_providers.nim
+++ b/tests/dht/test_providers.nim
@@ -21,6 +21,7 @@ import
   libp2p/crypto/crypto,
   libp2p/crypto/secp,
   libp2p/routing_record,
+  libp2p/multiaddress,
   libp2p/multihash,
   libp2p/multicodec,
   libp2p/signed_envelope
@@ -44,8 +45,7 @@ proc toSignedPeerRecord(privKey: crypto.PrivateKey) : SignedPeerRecord =
 
   let pr = PeerRecord.init(
     peerId = PeerId.init(privKey.getPublicKey.get).get,
-    seqNo = 0,
-    addresses = @[])
+    addresses = MultiAddress.udpExamples(3))
   return SignedPeerRecord.init(privKey, pr).expect("Should init SignedPeerRecord with private key")
   # trace "IDs", discNodeId, digest, mh, peerId=result.peerId.hex
 
@@ -62,8 +62,6 @@ proc bootstrapNodes(nodecount: int, bootnodes: openArray[Record], rng = keys.new
 
 proc bootstrapNetwork(nodecount: int, rng = keys.newRng()) : seq[(ProvidersProtocol, keys.PrivateKey)] =
   let
-    privKey = keys.PrivateKey.fromHex(
-      "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a617")[]
     bootNodeKey = keys.PrivateKey.fromHex(
       "a2b50376a79b1a8c8a3296485572bdfbf54708bb46d3c25d73d2723aaaf6a617")[]
     bootNodeAddr = localAddress(20301)
@@ -72,7 +70,7 @@ proc bootstrapNetwork(nodecount: int, rng = keys.newRng()) : seq[(ProvidersProto
   #waitFor bootNode.bootstrap()  # immediate, since no bootnodes are defined above
 
   result = bootstrapNodes(nodecount - 1, @[bootnode.discovery.localNode.record], rng = rng)
-  result.insert((bootNode, privKey), 0)
+  result.insert((bootNode, bootNodeKey), 0)
 
 # TODO: Remove this once we have removed all traces of nim-eth/keys
 func pkToPk(pk: keys.PrivateKey) : Option[crypto.PrivateKey] =


### PR DESCRIPTION
- Add example addresses in tests
- Change bootnode private key in tests
- bump libp2p to get access to SignedPeerRecord.encode