### PR TITLE
chore: remove nim-eth/keys in favour of libp2p/crypto

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,1 @@
+switch("define", "libp2p_pki_schemes=secp256k1")

--- a/libp2pdht/discv5.nim
+++ b/libp2pdht/discv5.nim
@@ -1,4 +1,4 @@
 import
-  ./discv5/[spr, encoding, messages, messages_encoding, node, nodes_verification, protocol, routing_table, sessions, transport]
+  ./discv5/[crypto, spr, encoding, messages, messages_encoding, node, nodes_verification, protocol, routing_table, sessions, transport]
 
-export spr, encoding, messages, messages_encoding, node, nodes_verification, protocol, routing_table, sessions, transport
+export crypto, spr, encoding, messages, messages_encoding, node, nodes_verification, protocol, routing_table, sessions, transport

--- a/libp2pdht/discv5/crypto.nim
+++ b/libp2pdht/discv5/crypto.nim
@@ -1,0 +1,4 @@
+import
+  ../private/eth/p2p/discoveryv5/crypto
+
+export crypto

--- a/libp2pdht/private/eth/p2p/discoveryv5/crypto.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/crypto.nim
@@ -1,0 +1,30 @@
+import
+  std/sugar,
+  libp2p/crypto/[crypto, secp]
+
+from secp256k1 import ecdhRaw, SkEcdhRawSecret, toRaw
+
+proc fromHex*(T: type PrivateKey, data: string): Result[PrivateKey, cstring] =
+  let skKey = ? SkPrivateKey.init(data).mapErr(e =>
+                ("Failed to init private key from hex string: " & $e).cstring)
+  ok PrivateKey.init(skKey)
+
+proc fromHex*(T: type PublicKey, data: string): Result[PublicKey, cstring] =
+  let skKey = ? SkPublicKey.init(data).mapErr(e =>
+                ("Failed to init public key from hex string: " & $e).cstring)
+  ok PublicKey.init(skKey)
+
+func ecdhRaw*(seckey: SkPrivateKey, pubkey: SkPublicKey): SkEcdhRawSecret {.borrow.}
+
+proc ecdhRaw*(
+    priv: PrivateKey,
+    pub: PublicKey): Result[SkEcdhRawSecret, cstring] =
+
+  # TODO: Do we need to support non-secp256k1 schemes?
+  if priv.scheme != Secp256k1 or pub.scheme != Secp256k1:
+    return err "Must use secp256k1 scheme".cstring
+
+  ok ecdhRaw(priv.skkey, pub.skkey)
+
+proc toRaw*(pubkey: PublicKey): seq[byte] =
+  secp256k1.SkPublicKey(pubkey.skkey).toRaw()[1..^1]

--- a/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -77,7 +77,8 @@ import
   std/[tables, sets, options, math, sequtils, algorithm],
   stew/shims/net as stewNet, json_serialization/std/net,
   stew/[base64, endians2, results], chronicles, chronos, chronos/timer, stint, bearssl,
-  metrics, eth/[rlp, keys, async_utils], libp2p/routing_record,
+  metrics, eth/[rlp, async_utils],
+  libp2p/[crypto/crypto, routing_record],
   "."/[transport, messages, messages_encoding, node, routing_table, spr, random2, ip_vote, nodes_verification]
 
 import nimcrypto except toHex
@@ -120,7 +121,7 @@ type
 
   Protocol* = ref object
     localNode*: Node
-    privateKey: keys.PrivateKey
+    privateKey: PrivateKey
     transport*: Transport[Protocol] # exported for tests
     routingTable*: RoutingTable
     awaitedMessages: Table[(NodeId, RequestId), Future[Option[Message]]]
@@ -214,7 +215,7 @@ proc neighboursAtDistances*(d: Protocol, distances: seq[uint16],
 
 proc nodesDiscovered*(d: Protocol): int = d.routingTable.len
 
-func privKey*(d: Protocol): lent keys.PrivateKey =
+func privKey*(d: Protocol): lent PrivateKey =
   d.privateKey
 
 func getRecord*(d: Protocol): SignedPeerRecord =
@@ -948,7 +949,7 @@ func init*(
   )
 
 proc newProtocol*(
-    privKey: keys.PrivateKey,
+    privKey: PrivateKey,
     enrIp: Option[ValidIpAddress],
     enrTcpPort, enrUdpPort: Option[Port],
     localEnrFields: openArray[(string, seq[byte])] = [],
@@ -958,7 +959,7 @@ proc newProtocol*(
     bindIp = IPv4_any(),
     enrAutoUpdate = false,
     config = defaultDiscoveryConfig,
-    rng = keys.newRng()):
+    rng = newRng()):
     Protocol =
   # TODO: Tried adding bindPort = udpPort as parameter but that gave
   # "Error: internal error: environment misses: udpPort" in nim-beacon-chain.

--- a/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
@@ -7,8 +7,10 @@
 # Everything below the handling of ordinary messages
 import
   std/[tables, options],
+  bearssl,
   chronos,
   chronicles,
+  libp2p/crypto/crypto,
   stew/shims/net,
   "."/[node, encoding, sessions]
 
@@ -124,8 +126,15 @@ proc receive*(t: Transport, a: Address, packet: openArray[byte]) =
         # This is a node we previously contacted and thus must have an address.
         doAssert(toNode.address.isSome())
         let address = toNode.address.get()
-        let data = encodeHandshakePacket(t.rng[], t.codec, toNode.id,
-          address, pr.message, packet.whoareyou, toNode.pubkey)
+        let data = encodeHandshakePacket(
+                    t.rng[],
+                    t.codec,
+                    toNode.id,
+                    address,
+                    pr.message,
+                    packet.whoareyou,
+                    toNode.pubkey
+                  ).expect("Valid handshake packet to encode")
 
         trace "Send handshake message packet", dstId = toNode.id, address
         t.send(toNode, data)


### PR DESCRIPTION
Closes: #2.

Libp2p supports multiple cryptographic curves, however we have currently only implented support for secp256k1.

This needs to be run with the compiler flag `libp2p_pki_schemes` set to `secp256k1`. If running the tests, this can be run like so: `nimble test —libp2p_pki_schemes=secp256k1` to put secp as the first supported crypto scheme.