### PR TITLE
replace providers:Table with providers:SQLiteDatastore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage
 nimcache
+tests/data
 tests/testAll

--- a/libp2pdht.nimble
+++ b/libp2pdht.nimble
@@ -19,7 +19,9 @@ requires "nim >= 1.2.0",
          "secp256k1 >= 0.5.2 & < 0.6.0",
          "stew#head",
          "stint",
-         "asynctest >= 0.3.1 & < 0.4.0"
+         "asynctest >= 0.3.1 & < 0.4.0",
+         "questionable >= 0.10.5 & < 0.11.0",
+         "https://github.com/status-im/nim-datastore"
 
 task coverage, "generates code coverage report":
   var (output, exitCode) = gorgeEx("which lcov")
@@ -57,4 +59,3 @@ task coverage, "generates code coverage report":
   exec("genhtml coverage/coverage.f.info --output-directory coverage/report")
   echo "Opening HTML coverage report in browser..."
   exec("open coverage/report/index.html")
-  

--- a/libp2pdht.nimble
+++ b/libp2pdht.nimble
@@ -21,7 +21,7 @@ requires "nim >= 1.2.0",
          "stint",
          "asynctest >= 0.3.1 & < 0.4.0",
          "questionable >= 0.10.5 & < 0.11.0",
-         "https://github.com/status-im/nim-datastore"
+         "https://github.com/status-im/nim-datastore#methods_close_query"
 
 task coverage, "generates code coverage report":
   var (output, exitCode) = gorgeEx("which lcov")

--- a/tests/dht/test_helper.nim
+++ b/tests/dht/test_helper.nim
@@ -1,6 +1,10 @@
 import
+  std/[oids, os]
+
+import
   bearssl,
   chronos,
+  datastore/sqlite_datastore,
   libp2p/crypto/[crypto, secp],
   libp2p/multiaddress,
   libp2pdht/discv5/[node, routing_table, spr],
@@ -22,6 +26,10 @@ proc example*(T: type NodeId, rng: ref HmacDrbgContext): NodeId =
     pubKey = privKey.getPublicKey.expect("Valid private key for public key")
   pubKey.toNodeId().expect("Public key valid for node id")
 
+const testDataDir* = "tests/data"
+
+proc randDbName*(): string = "dht_" & $genOid() & dbExt
+
 proc initDiscoveryNode*(
     rng: ref BrHmacDrbgContext,
     privKey: PrivateKey,
@@ -42,7 +50,9 @@ proc initDiscoveryNode*(
     localEnrFields = localEnrFields,
     previousRecord = previousRecord,
     config = config,
-    rng = rng)
+    rng = rng,
+    dataDir = testDataDir,
+    dbName = randDbName())
 
   protocol.open()
 

--- a/tests/dht/test_providers.nim
+++ b/tests/dht/test_providers.nim
@@ -10,7 +10,7 @@
 {.used.}
 
 import
-  std/[options, sequtils],
+  std/[options, os, sequtils],
   asynctest,
   bearssl,
   chronicles,
@@ -78,6 +78,9 @@ suite "Providers Tests: node alone":
     peerRec0: PeerRecord
 
   setupAll:
+    removeDir(testDataDir)
+    require(not dirExists(testDataDir))
+    createDir(testDataDir)
     rng = newRng()
     nodes = await bootstrapNetwork(nodecount=1)
     targetId = NodeId.example(rng)
@@ -89,6 +92,8 @@ suite "Providers Tests: node alone":
     for (n, _) in nodes:
       await n.closeWait()
     await sleepAsync(chronos.seconds(3))
+    removeDir(testDataDir)
+    require(not dirExists(testDataDir))
 
 
   test "Node in isolation should store":
@@ -99,7 +104,7 @@ suite "Providers Tests: node alone":
     debug "---- STARTING CHECKS ---"
     check (addedTo.len == 1)
     check (addedTo[0].id == node0.localNode.id)
-    check (node0.getProvidersLocal(targetId)[0].data.peerId == peerRec0.peerId)
+    check ((await node0.getProvidersLocal(targetId))[0].data.peerId == peerRec0.peerId)
 
   test "Node in isolation should retrieve":
 
@@ -138,8 +143,11 @@ suite "Providers Tests: two nodes":
     peerRec0: PeerRecord
 
   setupAll:
+    removeDir(testDataDir)
+    require(not dirExists(testDataDir))
+    createDir(testDataDir)
     rng = newRng()
-    nodes = await bootstrapNetwork(nodecount=3)
+    nodes = await bootstrapNetwork(nodecount=2)
     targetId = NodeId.example(rng)
     (node0, privKey0) = nodes[0]
     signedPeerRec0 = privKey0.toSignedPeerRecord
@@ -149,6 +157,8 @@ suite "Providers Tests: two nodes":
     for (n, _) in nodes:
       await n.closeWait()
     await sleepAsync(chronos.seconds(3))
+    removeDir(testDataDir)
+    require(not dirExists(testDataDir))
 
   test "2 nodes, store and retrieve from same":
 
@@ -187,6 +197,9 @@ suite "Providers Tests: 20 nodes":
     peerRec0: PeerRecord
 
   setupAll:
+    removeDir(testDataDir)
+    require(not dirExists(testDataDir))
+    createDir(testDataDir)
     rng = newRng()
     nodes = await bootstrapNetwork(nodecount=20)
     targetId = NodeId.example(rng)
@@ -199,6 +212,8 @@ suite "Providers Tests: 20 nodes":
   teardownAll:
     for (n, _) in nodes: # if last test is enabled, we need nodes[1..^1] here
       await n.closeWait()
+    removeDir(testDataDir)
+    require(not dirExists(testDataDir))
 
   test "20 nodes, store and retrieve from same":
 


### PR DESCRIPTION
In a previous team call we discussed #40: the importance of keeping the size of the in-memory providers store bounded as we work to test the correctness and resilience of nim-codex. At the end of the discussion it was realized that, while limiting the in-memory size is important, we need to persist SPRs else the effectiveness of the DHT could be degraded with respect to the overall network.

Such persistence should not be without limits in terms of time on disk and total amount of disk space used, but the implication is that the size of the persisted set should be larger than the amount of memory committed to caching SPRs.

I started work on a PR for #40 by looking at the possibility of an LRU cache that could be used as a layer in a `TieredDatastore` (of nim-datastore), with `SQLiteDatastore` as the persistence layer. I also considered a more ad hoc combination of an `LruCache` (either the type that's included in this repo or the one from [status-im/lrucache.nim](https://github.com/status-im/lrucache.nim)) and `SQLiteDatastore`.

Either approach involves difficulties, which I will describe in comments in #40. *Quick summary:* I think we should attempt to leverage SQLite's [Page Cache](https://www.sqlite.org/fileio.html#tocentry_132) by adjusting its size, and possibly the page size, to achieve a performance boost (fewer reads from disk) *without* putting our own cache (written in Nim) in front of the database. Let's have a discussion about that in #40.

The most important changes in this PR are in `libp2pdht/private/eth/p2p/discoveryv5/protocol.nim`: modifying `type Protocol` so that `providers: Table[NodeId, seq[SignedPeerRecord]]` becomes `providers: SQLiteDatastore`.

An important aspect is that nim-datastore provides a key-value store, while the table being replaced involves a one-to-many relationship.

If customizing usage of the SQLite wrapper provided by (and used by) nim-datastore is an option, there are several possibilities for dealing with one-to-many, including:
* using multiple tables and joins.
* enabling SQLite's [JSON support](https://www.sqlite.org/json1.html) and for each key (CID) storing an array of SPRs that is updated over time.

I chose to stick with vanilla datastore. For each row in the table, the key is a combination of the CID and a [fast hash](https://github.com/nim-lang/Nim/blob/version-1-6/lib/pure/hashes.nim#L302-L303) (murmur3) of the corresponding SPR: `/[cid]/[spr-hash]`. Lookup for all persisted SPRs for a particular CID is performed with query key `/[cid]/*`. There is a bit of overhead associated with this approach (more bytes stored/retrieved per SPR). We should discuss it in comments below.

With the switch from `Table` to `SQLiteDatastore` there is a need for additional error handling. At present (per this PR), those additional non-fatal errors are detected using `without` or `isErr` and then `trace` logged. That approach effectively swallows the errors, but the behavior of the DHT is not changed nor should its stability be reduced. However, we may want to consider switching from `trace` to `error` logging so those errors would surface when running production builds.

Limiting the size of the DHT store on disk is naturally related to https://github.com/status-im/nim-codex/issues/159 and can be implemented in a future PR.

There is some de-duplication of code in `protocol.nim` that can be done re: querying the datastore, but I'm waiting on that until we've decided if the approach taken so far is the one we want.