### PR TITLE
track nim-libp2p's unstable branch and nim-bearssl's master branch

### DIFF
--- a/libp2pdht.nimble
+++ b/libp2pdht.nimble
@@ -10,10 +10,10 @@ skipDirs      = @["tests"]
 # Dependencies
 requires "nim >= 1.2.0",
          "nimcrypto >= 0.5.4 & < 0.6.0",
-         "bearssl >= 0.1.5 & < 0.2.0",
+         "bearssl#head",
          "chronicles >= 0.10.2 & < 0.11.0",
          "chronos >= 3.0.11 & < 3.1.0",
-         "libp2p#c7504d2446717a48a79c8b15e0f21bbfc84957ba",
+         "libp2p#unstable",
          "metrics",
          "protobufserialization >= 0.2.0 & < 0.3.0",
          "secp256k1 >= 0.5.2 & < 0.6.0",
@@ -57,4 +57,4 @@ task coverage, "generates code coverage report":
   exec("genhtml coverage/coverage.f.info --output-directory coverage/report")
   echo "Opening HTML coverage report in browser..."
   exec("open coverage/report/index.html")
-  
+

--- a/libp2pdht/private/eth/p2p/discoveryv5/messages.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/messages.nim
@@ -14,7 +14,7 @@
 
 import
   std/[hashes, net],
-  bearssl,
+  bearssl/rand,
   ./spr,
   ./node,
   ../../../../dht/providers_messages
@@ -130,7 +130,7 @@ template messageKind*(T: typedesc[SomeMessage]): MessageKind =
 proc hash*(reqId: RequestId): Hash =
   hash(reqId.id)
 
-proc init*(T: type RequestId, rng: var BrHmacDrbgContext): T =
+proc init*(T: type RequestId, rng: var HmacDrbgContext): T =
   var reqId = RequestId(id: newSeq[byte](8)) # RequestId must be <= 8 bytes
-  brHmacDrbgGenerate(rng, reqId.id)
+  hmacDrbgGenerate(rng, reqId.id)
   reqId

--- a/libp2pdht/private/eth/p2p/discoveryv5/node.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/node.nim
@@ -9,7 +9,7 @@
 
 import
   std/hashes,
-  bearssl,
+  bearssl/rand,
   chronicles,
   chronos,
   nimcrypto,
@@ -99,9 +99,9 @@ func `==`*(a, b: Node): bool =
 func hash*(id: NodeId): Hash =
   hash(id.toByteArrayBE)
 
-proc random*(T: type NodeId, rng: var BrHmacDrbgContext): T =
+proc random*(T: type NodeId, rng: var HmacDrbgContext): T =
   var id: NodeId
-  brHmacDrbgGenerate(addr rng, addr id, csize_t(sizeof(id)))
+  hmacDrbgGenerate(rng, addr id, csize_t(sizeof(id)))
 
   id
 

--- a/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/protocol.nim
@@ -76,7 +76,7 @@
 import
   std/[tables, sets, options, math, sequtils, algorithm, strutils],
   stew/shims/net as stewNet, json_serialization/std/net,
-  stew/[base64, endians2, results], chronicles, chronicles/chronos_tools, chronos, chronos/timer, stint, bearssl,
+  stew/[base64, endians2, results], chronicles, chronicles/chronos_tools, chronos, chronos/timer, stint, bearssl/rand,
   metrics,
   libp2p/[crypto/crypto, routing_record],
   "."/[transport, messages, messages_encoding, node, routing_table, spr, random2, ip_vote, nodes_verification, lru]
@@ -159,7 +159,7 @@ type
     enrAutoUpdate: bool
     talkProtocols*: Table[seq[byte], TalkProtocol] # TODO: Table is a bit of
     # overkill here, use sequence
-    rng*: ref BrHmacDrbgContext
+    rng*: ref HmacDrbgContext
     providers: ItemsCache
 
   TalkProtocolHandler* = proc(p: TalkProtocol, request: seq[byte], fromId: NodeId, fromUdpAddress: Address): seq[byte]

--- a/libp2pdht/private/eth/p2p/discoveryv5/random2.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/random2.nim
@@ -1,22 +1,22 @@
-import bearssl
+import bearssl/rand
 
-## Random helpers: similar as in stdlib, but with BrHmacDrbgContext rng
+## Random helpers: similar as in stdlib, but with HmacDrbgContext rng
 # TODO: Move these somewhere else?
 const randMax = 18_446_744_073_709_551_615'u64
 
-proc rand*(rng: var BrHmacDrbgContext, max: Natural): int =
+proc rand*(rng: var HmacDrbgContext, max: Natural): int =
   if max == 0: return 0
 
   var x: uint64
   while true:
-    brHmacDrbgGenerate(addr rng, addr x, csize_t(sizeof(x)))
+    hmacDrbgGenerate(rng, addr x, csize_t(sizeof(x)))
     if x < randMax - (randMax mod (uint64(max) + 1'u64)): # against modulo bias
       return int(x mod (uint64(max) + 1'u64))
 
-proc sample*[T](rng: var BrHmacDrbgContext, a: openArray[T]): T =
+proc sample*[T](rng: var HmacDrbgContext, a: openArray[T]): T =
   result = a[rng.rand(a.high)]
 
-proc shuffle*[T](rng: var BrHmacDrbgContext, a: var openArray[T]) =
+proc shuffle*[T](rng: var HmacDrbgContext, a: var openArray[T]) =
   for i in countdown(a.high, 1):
     let j = rng.rand(i)
     swap(a[i], a[j])

--- a/libp2pdht/private/eth/p2p/discoveryv5/routing_table.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/routing_table.nim
@@ -9,7 +9,7 @@
 
 import
   std/[algorithm, times, sequtils, bitops, sets, options, tables],
-  stint, chronicles, metrics, bearssl, chronos, stew/shims/net as stewNet,
+  stint, chronicles, metrics, bearssl/rand, chronos, stew/shims/net as stewNet,
   "."/[node, random2, spr]
 
 export options
@@ -46,7 +46,7 @@ type
     ipLimits: IpLimits ## IP limits for total routing table: all buckets and
     ## replacement caches.
     distanceCalculator: DistanceCalculator
-    rng: ref BrHmacDrbgContext
+    rng: ref HmacDrbgContext
 
   KBucket = ref object
     istart, iend: NodeId ## Range of NodeIds this KBucket covers. This is not a
@@ -278,7 +278,7 @@ proc computeSharedPrefixBits(nodes: openArray[NodeId]): int =
   doAssert(false, "Unable to calculate number of shared prefix bits")
 
 proc init*(T: type RoutingTable, localNode: Node, bitsPerHop = DefaultBitsPerHop,
-    ipLimits = DefaultTableIpLimits, rng: ref BrHmacDrbgContext,
+    ipLimits = DefaultTableIpLimits, rng: ref HmacDrbgContext,
     distanceCalculator = XorDistanceCalculator): T =
   ## Initialize the routing table for provided `Node` and bitsPerHop value.
   ## `bitsPerHop` is default set to 5 as recommended by original Kademlia paper.

--- a/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
+++ b/libp2pdht/private/eth/p2p/discoveryv5/transport.nim
@@ -7,7 +7,7 @@
 # Everything below the handling of ordinary messages
 import
   std/[tables, options],
-  bearssl,
+  bearssl/rand,
   chronos,
   chronicles,
   libp2p/crypto/crypto,
@@ -27,7 +27,7 @@ type
     transp: DatagramTransport
     pendingRequests: Table[AESGCMNonce, PendingRequest]
     codec*: Codec
-    rng: ref BrHmacDrbgContext
+    rng: ref HmacDrbgContext
 
   PendingRequest = object
     node: Node

--- a/tests/dht/test_helper.nim
+++ b/tests/dht/test_helper.nim
@@ -1,5 +1,5 @@
 import
-  bearssl,
+  bearssl/rand,
   chronos,
   libp2p/crypto/[crypto, secp],
   libp2p/multiaddress,
@@ -23,7 +23,7 @@ proc example*(T: type NodeId, rng: ref HmacDrbgContext): NodeId =
   pubKey.toNodeId().expect("Public key valid for node id")
 
 proc initDiscoveryNode*(
-    rng: ref BrHmacDrbgContext,
+    rng: ref HmacDrbgContext,
     privKey: PrivateKey,
     address: Address,
     bootstrapRecords: openArray[SignedPeerRecord] = [],
@@ -60,7 +60,7 @@ proc generateNode*(privKey: PrivateKey, port: int = 20302,
               .expect("Properly intialized private key")
   result = newNode(spr).expect("Properly initialized node")
 
-proc generateNRandomNodes*(rng: ref BrHmacDrbgContext, n: int): seq[Node] =
+proc generateNRandomNodes*(rng: ref HmacDrbgContext, n: int): seq[Node] =
   var res = newSeq[Node]()
   for i in 1..n:
     let
@@ -69,7 +69,7 @@ proc generateNRandomNodes*(rng: ref BrHmacDrbgContext, n: int): seq[Node] =
     res.add(node)
   res
 
-proc nodeAndPrivKeyAtDistance*(n: Node, rng: var BrHmacDrbgContext, d: uint32,
+proc nodeAndPrivKeyAtDistance*(n: Node, rng: var HmacDrbgContext, d: uint32,
     ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): (Node, PrivateKey) =
   while true:
     let
@@ -78,19 +78,19 @@ proc nodeAndPrivKeyAtDistance*(n: Node, rng: var BrHmacDrbgContext, d: uint32,
     if logDistance(n.id, node.id) == d:
       return (node, privKey)
 
-proc nodeAtDistance*(n: Node, rng: var BrHmacDrbgContext, d: uint32,
+proc nodeAtDistance*(n: Node, rng: var HmacDrbgContext, d: uint32,
     ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): Node =
   let (node, _) = n.nodeAndPrivKeyAtDistance(rng, d, ip)
   node
 
 proc nodesAtDistance*(
-    n: Node, rng: var BrHmacDrbgContext, d: uint32, amount: int,
+    n: Node, rng: var HmacDrbgContext, d: uint32, amount: int,
     ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): seq[Node] =
   for i in 0..<amount:
     result.add(nodeAtDistance(n, rng, d, ip))
 
 proc nodesAtDistanceUniqueIp*(
-    n: Node, rng: var BrHmacDrbgContext, d: uint32, amount: int,
+    n: Node, rng: var HmacDrbgContext, d: uint32, amount: int,
     ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): seq[Node] =
   var ta = initTAddress(ip, Port(0))
   for i in 0..<amount:

--- a/tests/dht/test_providers.nim
+++ b/tests/dht/test_providers.nim
@@ -12,7 +12,7 @@
 import
   std/[options, sequtils],
   asynctest,
-  bearssl,
+  bearssl/rand,
   chronicles,
   chronos,
   nimcrypto,

--- a/tests/discv5/test_discoveryv5.nim
+++ b/tests/discv5/test_discoveryv5.nim
@@ -3,7 +3,7 @@
 import
   std/tables,
   chronos, chronicles, stint, asynctest, stew/shims/net,
-  stew/byteutils, bearssl,
+  stew/byteutils, bearssl/rand,
   libp2p/crypto/crypto,
   libp2pdht/discv5/[transport, spr, node, routing_table, encoding, sessions, messages, nodes_verification],
   libp2pdht/discv5/crypto as dhtcrypto,

--- a/tests/discv5/test_discoveryv5_encoding.nim
+++ b/tests/discv5/test_discoveryv5_encoding.nim
@@ -3,7 +3,7 @@
 import
   std/[options, sequtils, tables],
   asynctest/unittest2,
-  bearssl,
+  bearssl/rand,
   chronos,
   libp2p/crypto/secp,
   libp2pdht/discv5/[messages, messages_encoding, encoding, spr, node, sessions],
@@ -480,7 +480,7 @@ suite "Discovery v5.1 Additional Encode/Decode":
 
   test "Encrypt / Decrypt header":
     var nonce: AESGCMNonce
-    brHmacDrbgGenerate(rng[], nonce)
+    hmacDrbgGenerate(rng[], nonce)
     let
       nodeId = NodeId.example(rng)
       authdata = newSeq[byte](32)
@@ -489,7 +489,7 @@ suite "Discovery v5.1 Additional Encode/Decode":
       header = staticHeader & authdata
 
     var iv: array[128 div 8, byte]
-    brHmacDrbgGenerate(rng[], iv)
+    hmacDrbgGenerate(rng[], iv)
 
     let
       encrypted = encryptHeader(nodeId, iv, header)
@@ -538,7 +538,7 @@ suite "Discovery v5.1 Additional Encode/Decode":
 
   test "Encode / Decode Whoareyou Packet":
     var requestNonce: AESGCMNonce
-    brHmacDrbgGenerate(rng[], requestNonce)
+    hmacDrbgGenerate(rng[], requestNonce)
     let recordSeq = 0'u64
 
     let data = encodeWhoareyouPacket(rng[], codecA, nodeB.id,
@@ -559,7 +559,7 @@ suite "Discovery v5.1 Additional Encode/Decode":
 
   test "Encode / Decode Handshake Message Packet":
     var requestNonce: AESGCMNonce
-    brHmacDrbgGenerate(rng[], requestNonce)
+    hmacDrbgGenerate(rng[], requestNonce)
     let
       recordSeq = 1'u64
       m = PingMessage(sprSeq: 0)
@@ -595,7 +595,7 @@ suite "Discovery v5.1 Additional Encode/Decode":
 
   test "Encode / Decode Handshake Message Packet with SPR":
     var requestNonce: AESGCMNonce
-    brHmacDrbgGenerate(rng[], requestNonce)
+    hmacDrbgGenerate(rng[], requestNonce)
     let
       recordSeq = 0'u64
       m = PingMessage(sprSeq: 0)


### PR DESCRIPTION
Refactor accordingly: mainly switching from `import bearssl` to `import bearssl/rand`, `BrHmacDrbgContext` to `HmacDrbgContext`, and related changes.

Closes #48.